### PR TITLE
fix: [INTEG-2092] - Reorganize exports

### DIFF
--- a/lib/app-router/handlers/app.spec.ts
+++ b/lib/app-router/handlers/app.spec.ts
@@ -1,7 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { redirect } from 'next/navigation';
 import { NextRequest } from 'next/server';
-import { enableDraftHandler as GET } from './app-router';
+import { enableDraftHandler as GET } from './app';
 
 vi.mock('next/navigation', () => {
   return {
@@ -93,7 +93,7 @@ describe('handler', () => {
           `https://vercel-app-router-integrations-ll9uxwb4f.vercel.app/blogs/my-cat?x-vercel-protection-bypass=${bypassToken}&x-vercel-set-bypass-cookie=samesitenone`,
         );
       });
-    })
+    });
   });
 
   describe('when the bypass token is wrong', () => {

--- a/lib/app-router/handlers/app.ts
+++ b/lib/app-router/handlers/app.ts
@@ -5,14 +5,19 @@ import { NextRequest } from 'next/server';
 export async function enableDraftHandler(
   request: NextRequest,
 ): Promise<Response | void> {
-  const { origin: base, path, host, bypassToken: bypassTokenFromQuery } = parseRequestUrl(request.url);
+  const {
+    origin: base,
+    path,
+    host,
+    bypassToken: bypassTokenFromQuery,
+  } = parseRequestUrl(request.url);
 
-  let bypassToken: string
-  let aud: string
+  let bypassToken: string;
+  let aud: string;
 
   if (bypassTokenFromQuery) {
-    bypassToken = bypassTokenFromQuery
-    aud = host
+    bypassToken = bypassTokenFromQuery;
+    aud = host;
   } else {
     // if x-vercel-protection-bypass not provided in query, we defer to parsing the _vercel_jwt cookie
     // which bundlees the bypass token value in its payload
@@ -26,8 +31,8 @@ export async function enableDraftHandler(
         { status: 401 },
       );
     }
-    bypassToken = vercelJwt.bypass
-    aud = vercelJwt.aud
+    bypassToken = vercelJwt.bypass;
+    aud = vercelJwt.aud;
   }
 
   if (bypassToken !== process.env.VERCEL_AUTOMATION_BYPASS_SECRET) {
@@ -114,7 +119,7 @@ const parseRequestUrl = (
 const buildRedirectUrl = ({
   path,
   base,
-  bypassTokenFromQuery
+  bypassTokenFromQuery,
 }: {
   path: string;
   base: string;
@@ -125,8 +130,11 @@ const buildRedirectUrl = ({
   // if the bypass token is provided in the query, we assume Vercel has _not_ already set the actual
   // token that bypasses authentication. thus we provided it here, on the redirect
   if (bypassTokenFromQuery) {
-    redirectUrl.searchParams.set('x-vercel-protection-bypass', bypassTokenFromQuery)
-    redirectUrl.searchParams.set('x-vercel-set-bypass-cookie', 'samesitenone')
+    redirectUrl.searchParams.set(
+      'x-vercel-protection-bypass',
+      bypassTokenFromQuery,
+    );
+    redirectUrl.searchParams.set('x-vercel-set-bypass-cookie', 'samesitenone');
   }
 
   return redirectUrl.toString();

--- a/lib/app-router/handlers/index.ts
+++ b/lib/app-router/handlers/index.ts
@@ -1,1 +1,1 @@
-export * from './app-router';
+export * from './app';

--- a/lib/app-router/index.ts
+++ b/lib/app-router/index.ts
@@ -1,1 +1,1 @@
-export * from './handlers/app-router';
+export * from './handlers';

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -1,0 +1,1 @@
+export * from './app-router';

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@contentful/vercel-nextjs-toolkit",
-  "version": "1.2.2",
+  "version": "1.2.4",
   "author": "Contentful",
   "license": "MIT",
   "description": "Contentful helper SDK for Vercel platform app integration to enable live preview",

--- a/package.json
+++ b/package.json
@@ -20,9 +20,9 @@
       "types": "./dist/main.d.ts"
     },
     "./app-router": {
-      "import": "./dist/app-router/index.js",
-      "require": "./dist/app-router/index.js",
-      "types": "./dist/app-router/index.d.ts"
+      "import": "./dist/app-router/handlers/app.js",
+      "require": "./dist/app-router/handlers/app.js",
+      "types": "./dist/app-router/handlers/app.d.ts"
     }
   },
   "repository": {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -12,15 +12,19 @@ export default defineConfig({
     }),
   ],
   build: {
-    lib: {
-      entry: resolve(__dirname, 'lib/main.ts'),
-      formats: ['es'],
-      fileName: () => 'main.js',
-    },
-    minify: false,
     ssr: true,
+    minify: false,
+    lib: {
+      entry: resolve(__dirname, 'lib/index.ts'),
+      formats: ['es'],
+      fileName: () => 'index.js',
+    },
     rollupOptions: {
       external: [...Object.keys(pkg.peerDependencies)],
+      output: {
+        preserveModules: true,
+        preserveModulesRoot: 'lib',
+      },
     },
   },
 });


### PR DESCRIPTION
## Purpose

- This includes in our bundled output `app-router` and handlers to enable importing top level like so:


```typescript
export { enableDraftHandler as GET } from "@contentful/vercel-nexjts-toolkit/app-router";
```