### PR TITLE
fix: disable JWT check if NODE_ENV equals development.

### DIFF
--- a/lib/app-router/handlers/app.ts
+++ b/lib/app-router/handlers/app.ts
@@ -12,6 +12,13 @@ export async function enableDraftHandler(
     bypassToken: bypassTokenFromQuery,
   } = parseRequestUrl(request.url);
 
+  // if we're in development, we don't need to check for a bypass token, and we can just enable draft mode
+  if (process.env.NODE_ENV === 'development') {
+    draftMode().enable();
+    const redirectUrl = buildRedirectUrl({ path, base, bypassTokenFromQuery });
+    return redirect(redirectUrl);
+  }
+
   let bypassToken: string;
   let aud: string;
 


### PR DESCRIPTION
## Purpose

Enable draft mode while in development

## Description

This code checks the NODE_ENV variable and if it equals "development" we bypass the JWT checking and immediately enable draft mode and redirect

## Testing steps

Use the package with `npm run dev` (or similar) and enable draft mode using our route handler.

## Breaking Changes

No

## Design, Documentation, and/or References

Feedback from Vercel team

## Deployment

A user could potentially deploy their production app with the wrong node environment, but that's outside the scope of responsibility for this SDK. Deployments on Vercel won't be susceptible to this since both Production and Preview deployments use Node in production environment
