### PR TITLE
fix: hide bypass token on redirect when cookie is present

### DIFF
--- a/lib/pages-router/handlers/enable-draft.spec.ts
+++ b/lib/pages-router/handlers/enable-draft.spec.ts
@@ -85,6 +85,23 @@ describe('handler', () => {
     });
   });
 
+  describe('when a x-vercel-protection-bypass token is also provided as a query param', () => {
+    beforeEach(() => {
+      const url = `https://vercel-app-router-integrations-ll9uxwb4f.vercel.app/api/enable-draft?path=%2Fblogs%2Fmy-cat&x-vercel-protection-bypass=${bypassToken}`;
+      request = makeNextApiRequest(url);
+      request.cookies['_vercel_jwt'] = vercelJwt;
+    });
+
+    it('redirects safely to the provided path and DOES NOT pass through the token and bypass cookie query params', async () => {
+      const result = await handler(request, response);
+      expect(result).to.be.undefined;
+      expect(apiResponseSpy.setDraftMode).toHaveBeenCalledWith({ enable: true });
+      expect(apiResponseSpy.redirect).toHaveBeenCalledWith(
+        `https://vercel-app-router-integrations-ll9uxwb4f.vercel.app/blogs/my-cat`,
+      );
+    });
+  });
+
   describe('when the _vercel_jwt cookie is missing', () => {
     beforeEach(() => {
       const url = `https://vercel-app-router-integrations-ll9uxwb4f.vercel.app/api/enable-draft?path=%2Fblogs%2Fmy-cat`;

--- a/lib/utils/vercelJwt.spec.ts
+++ b/lib/utils/vercelJwt.spec.ts
@@ -2,7 +2,7 @@ import { beforeEach, describe, expect, it } from 'vitest';
 import { getVercelJwtCookie, parseVercelJwtCookie } from './vercelJwt';
 import { NextRequest } from 'next/server';
 
-describe.only('getVercelJwtCookie', () => {
+describe('getVercelJwtCookie', () => {
   const url = 'http://example.com'
   let request: NextRequest
 

--- a/lib/utils/vercelJwt.spec.ts
+++ b/lib/utils/vercelJwt.spec.ts
@@ -1,15 +1,31 @@
-import { describe, expect, it } from 'vitest';
+import { beforeEach, describe, expect, it } from 'vitest';
 import { getVercelJwtCookie, parseVercelJwtCookie } from './vercelJwt';
 import { NextRequest } from 'next/server';
 
-describe('getVercelJwtCookie', () => {
+describe.only('getVercelJwtCookie', () => {
   const url = 'http://example.com'
-  const request = new NextRequest(url);
-  request.cookies.set('_vercel_jwt', 'vercel-jwt');
+  let request: NextRequest
+
+  beforeEach(() => {
+    request = new NextRequest(url);
+    request.cookies.set('_vercel_jwt', 'vercel-jwt');
+  })
 
   it('returns the _vercel_jwt cookie', () => {
     const result = getVercelJwtCookie(request)
     expect(result).toEqual('vercel-jwt')
+  })
+
+  describe('when cookie is not present', () => {
+    beforeEach(() => {
+      request = new NextRequest(url);
+      request.cookies.clear()
+    })
+
+    it('returns undefined', () => {
+      const result = getVercelJwtCookie(request)
+      expect(result).to.equal(undefined)
+    })
   })
 })
 

--- a/lib/utils/vercelJwt.ts
+++ b/lib/utils/vercelJwt.ts
@@ -1,9 +1,9 @@
 import { NextRequest } from "next/server";
 import { type VercelJwt } from "../types";
 
-export const getVercelJwtCookie = (request: NextRequest): string => {
+export const getVercelJwtCookie = (request: NextRequest): string | undefined => {
   const vercelJwtCookie = request.cookies.get('_vercel_jwt');
-  if (!vercelJwtCookie) throw new Error('`_vercel_jwt` cookie not set');
+  if (!vercelJwtCookie) return;
   return vercelJwtCookie.value;
 }
 


### PR DESCRIPTION
## Purpose

When redirecting to the correct URL after enabling Draft Mode, we need to be conscientious about how bypass protection token is handled in the query parameter.

Normally, if Vercel detects the present of `x-vercel-protection-bypass` as a query parameter it will strip the value after setting the `_vercel_jwt` cookie and redirecting to the original destination. However, if a _vercel_jwt cookie is already set then Vercel will _not_ strip that query parameter.

In our case that meant that the token was ending up in the final redirect, which potentially exposes the token in an unwanted fashion.

## Approach

* Check for presence of `_vercel_jwt` cookie when preparing final redirect URL, and don't include token if it is found

## Testing steps

<!-- Where can the user find this component to test its functionality? -->

## Breaking Changes

<!-- Are there any changes to be aware of that would break current production build? -->

## Design, Documentation, and/or References

<!-- What original designs are associated with this component? Where can we get more insights about this change? (Tickets, wiki pages or links to other places/docs -- no private/internal links please) -->

## Deployment

<!-- (Optional) Are there any deployment-related tasks, concerns or risks we should be mindful of? -->
