### PR TITLE
feat: support x-contentful-preview-secret for hobby accounts

### DIFF
--- a/lib/app-router/handlers/enable-draft.spec.ts
+++ b/lib/app-router/handlers/enable-draft.spec.ts
@@ -105,6 +105,24 @@ describe('handler', () => {
       expect(result).toHaveProperty('status', 401);
     });
 
+    describe('when a x-contentful-preview-secret is provided as a query param', () => {
+      beforeEach(() => {
+        vi.stubEnv('VERCEL_AUTOMATION_BYPASS_SECRET', '');
+        vi.stubEnv('CONTENTFUL_PREVIEW_SECRET', bypassToken);
+        const url = `https://vercel-app-router-integrations-ll9uxwb4f.vercel.app/api/enable-draft?path=%2Fblogs%2Fmy-cat&x-contentful-preview-secret=${bypassToken}`;
+        request = new NextRequest(url);
+      });
+
+      it('redirects safely to the provided path and DOES NOT pass through the token and bypass cookie query params', async () => {
+        const result = await GET(request);
+        expect(result).to.be.undefined;
+        expect(draftModeMock.enable).toHaveBeenCalled();
+        expect(vi.mocked(redirect)).toHaveBeenCalledWith(
+          `https://vercel-app-router-integrations-ll9uxwb4f.vercel.app/blogs/my-cat`,
+        );
+      });
+    });
+
     describe('when a x-vercel-protection-bypass token is provided as a query param', () => {
       beforeEach(() => {
         const url = `https://vercel-app-router-integrations-ll9uxwb4f.vercel.app/api/enable-draft?path=%2Fblogs%2Fmy-cat&x-vercel-protection-bypass=${bypassToken}`;

--- a/lib/app-router/handlers/enable-draft.ts
+++ b/lib/app-router/handlers/enable-draft.ts
@@ -57,7 +57,7 @@ export async function enableDraftHandler(
     aud = vercelJwt.aud;
   }
 
-  // hobby Vercel accounts may not have a VERCEL_AUTOMATION_BYPASS_SECRET, so we fallback to checking the value against the CONTENTFUL_PREVIEW_SECRET
+  // certain Vercel account tiers may not have a VERCEL_AUTOMATION_BYPASS_SECRET, so we fallback to checking the value against the CONTENTFUL_PREVIEW_SECRET
   // env var, which is supported as a workaround for these accounts
   if ((bypassToken !== process.env.VERCEL_AUTOMATION_BYPASS_SECRET) && (contentfulPreviewSecretFromQuery !== process.env.CONTENTFUL_PREVIEW_SECRET)) {
     return new Response(

--- a/lib/pages-router/handlers/enable-draft.spec.ts
+++ b/lib/pages-router/handlers/enable-draft.spec.ts
@@ -114,6 +114,25 @@ describe('handler', () => {
       expect(apiResponseSpy.send).toHaveBeenCalledWith(expect.any(String));
     });
 
+    describe('when a x-contentful-preview-secret is provided as a query param', () => {
+      beforeEach(() => {
+        vi.stubEnv('VERCEL_AUTOMATION_BYPASS_SECRET', '');
+        vi.stubEnv('CONTENTFUL_PREVIEW_SECRET', bypassToken);
+        const url = `https://vercel-app-router-integrations-ll9uxwb4f.vercel.app/api/enable-draft?path=%2Fblogs%2Fmy-cat&x-contentful-preview-secret=${bypassToken}`;
+        request = makeNextApiRequest(url);
+      });
+
+      it('redirects safely to the provided path and DOES NOT passes through the token and bypass cookie query params', async () => {
+        const result = await handler(request, response);
+        expect(result).to.be.undefined;
+        expect(apiResponseSpy.setDraftMode).toHaveBeenCalledWith({ enable: true });
+        expect(apiResponseSpy.redirect).toHaveBeenCalledWith(
+          `https://vercel-app-router-integrations-ll9uxwb4f.vercel.app/blogs/my-cat`,
+        );
+      });
+    });
+
+
     describe('when a x-vercel-protection-bypass token is provided as a query param', () => {
       beforeEach(() => {
         const url = `https://vercel-app-router-integrations-ll9uxwb4f.vercel.app/api/enable-draft?path=%2Fblogs%2Fmy-cat&x-vercel-protection-bypass=${bypassToken}`;

--- a/lib/pages-router/handlers/enable-draft.ts
+++ b/lib/pages-router/handlers/enable-draft.ts
@@ -56,7 +56,7 @@ export const enableDraftHandler: NextApiHandler = async (
     aud = vercelJwt.aud;
   }
 
-  // hobby Vercel accounts may not have a VERCEL_AUTOMATION_BYPASS_SECRET, so we fallback to checking the value against the CONTENTFUL_PREVIEW_SECRET
+  // certain Vercel account tiers may not have a VERCEL_AUTOMATION_BYPASS_SECRET, so we fallback to checking the value against the CONTENTFUL_PREVIEW_SECRET
   // env var, which is supported as a workaround for these accounts
   if ((bypassToken !== process.env.VERCEL_AUTOMATION_BYPASS_SECRET) && (contentfulPreviewSecretFromQuery !== process.env.CONTENTFUL_PREVIEW_SECRET)) {
     response.status(403).send(

--- a/lib/utils/url.spec.ts
+++ b/lib/utils/url.spec.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from 'vitest';
 import { buildRedirectUrl, parseNextApiRequest, parseRequestUrl } from './url';
 import { makeNextApiRequest } from '../../test/helpers';
 
-const requestUrl = `https://my.vercel.app/api/enable-draft?path=%2Fblogs%2Fmy-cat&x-vercel-protection-bypass=foo`;
+const requestUrl = `https://my.vercel.app/api/enable-draft?path=%2Fblogs%2Fmy-cat&x-vercel-protection-bypass=foo&x-contentful-preview-secret=bar`;
 
 describe('parseNextApiRequest', () => {
   const request = makeNextApiRequest(requestUrl);
@@ -12,6 +12,7 @@ describe('parseNextApiRequest', () => {
     expect(result).toHaveProperty('origin', 'https://my.vercel.app')
     expect(result).toHaveProperty('host', 'my.vercel.app')
     expect(result).toHaveProperty('bypassToken', 'foo')
+    expect(result).toHaveProperty('contentfulPreviewSecret', 'bar')
     expect(result).toHaveProperty('path', '/blogs/my-cat')
   })
 })

--- a/lib/utils/url.ts
+++ b/lib/utils/url.ts
@@ -5,6 +5,7 @@ interface ParsedRequestUrl {
   host: string;
   path: string;
   bypassToken: string;
+  contentfulPreviewSecret: string;
 }
 
 export const parseNextApiRequest = (
@@ -16,8 +17,7 @@ export const parseNextApiRequest = (
   const protocol = request.headers['x-forwarded-proto'] || 'https'
   const requestUrl = request.url && new URL(request.url, `${protocol}://${hostHeader}`).toString()
 
-  const { origin, path, host, bypassToken } = parseRequestUrl(requestUrl)
-  return { origin, path, host, bypassToken };
+  return parseRequestUrl(requestUrl)
 }
 
 export const parseRequestUrl = (
@@ -28,12 +28,13 @@ export const parseRequestUrl = (
 
   const rawPath = searchParams.get('path') || '';
   const bypassToken = searchParams.get('x-vercel-protection-bypass') || '';
+  const contentfulPreviewSecret = searchParams.get('x-contentful-preview-secret') || '';
 
   // to allow query parameters to be passed through to the redirected URL, the original `path` should already be
   // URI encoded, and thus must be decoded here
   const path = decodeURIComponent(rawPath);
 
-  return { origin, path, host, bypassToken };
+  return { origin, path, host, bypassToken, contentfulPreviewSecret };
 };
 
 export const buildRedirectUrl = ({


### PR DESCRIPTION
## Purpose

We had a recent learning that Vercel's Protection Bypass for Automation feature is not available for free aka "hobby" Vercel accounts:

<img width="1163" alt="image" src="https://github.com/contentful/vercel-nextjs-toolkit/assets/235836/56e82d43-03d4-4e6a-bd8c-9ef39ab6fca5">

In order to make the enable draft route handler work for these customers, we would like to support setting an environment variable `CONTENTFUL_PREVIEW_SECRET` to hold the preview "secret", which would work as a fallback for customers that do not have the protection bypass feature enabled.

## Approach

* Add support for an `x-contentful-preview-secret` query parameter that passes down a value to be compared with a `CONTENTFUL_PREVIEW_SECRET` env var if this is provided



## Testing steps

<!-- Where can the user find this component to test its functionality? -->

## Breaking Changes

<!-- Are there any changes to be aware of that would break current production build? -->

## Design, Documentation, and/or References

<!-- What original designs are associated with this component? Where can we get more insights about this change? (Tickets, wiki pages or links to other places/docs -- no private/internal links please) -->

## Deployment

<!-- (Optional) Are there any deployment-related tasks, concerns or risks we should be mindful of? -->
