### PR TITLE
Update module resolution to Node.

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,7 +7,7 @@
     "skipLibCheck": true,
 
     /* Bundler mode */
-    "moduleResolution": "bundler",
+    "moduleResolution": "node",
     "allowImportingTsExtensions": true,
     "resolveJsonModule": true,
     "isolatedModules": true,


### PR DESCRIPTION
## Purpose

This is the most widely used setting and is compatible with Node.js module resolution logic, making it suitable for both Node.js and many frontend projects, including Next.js.

While working on our Next.js monorepo, the module resolution "bundler" broke the site.

## Description

N/A

## Testing steps

Run normal tests. No changes made.

## Breaking Changes

I don't believe there are any breaking changes.

## Design, Documentation, and/or References

N/A

## Deployment

Since Next.js uses Node resolution internally, this should not affect end users.
