### PR TITLE
docs: add golden context files for AI agent navigation [TRANS-13]

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,50 @@
+# Agent Guide — @contentful/vercel-nextjs-toolkit
+
+## What This Repo Does
+A small Next.js helper library for Contentful customers hosting on Vercel. Provides route handlers that activate [Next.js Draft Mode](https://nextjs.org/docs/app/building-your-application/configuring/draft-mode) using Vercel's Protection Bypass for Automation feature — enabling content editors to preview unpublished content via Contentful's content preview integration.
+
+Companion to the Contentful Vercel Marketplace App.
+
+## Ownership
+`@contentful/team-marketplace` (full, sole owner)
+
+## Structure
+
+```
+lib/
+├── app-router/handlers/enable-draft.ts    # Next.js App Router route handler
+├── pages-router/handlers/enable-draft.ts  # Next.js Pages Router API route handler
+├── utils/
+│   ├── vercelJwt.ts                       # JWT parsing + bypass token validation
+│   └── url.ts                             # URL parsing + redirect construction
+└── types.ts                               # VercelJwt interface
+```
+
+## Published as Two Subpath Exports
+
+```typescript
+// App Router (Next.js 13+ app/ directory)
+import { enableDraftHandler } from '@contentful/vercel-nextjs-toolkit/app-router'
+
+// Pages Router (Next.js pages/ directory)
+import { enableDraftHandler } from '@contentful/vercel-nextjs-toolkit/pages-router'
+```
+
+## Sharp Edges & Invariants
+
+- **Dual export format** — `dist/app-router.js` (ESM) + `dist/app-router.cjs` (CJS), and same for pages-router. Both must be present in any release.
+- **No production dependencies** — this is a zero-dependency library. Do not add runtime dependencies without very strong justification; consumers install it as a lightweight helper.
+- **Two environment variables drive token validation**:
+  - `VERCEL_AUTOMATION_BYPASS_SECRET` — primary (for Vercel Pro/Enterprise accounts)
+  - `CONTENTFUL_PREVIEW_SECRET` — fallback (for hobby accounts without Vercel bypass)
+  - `NODE_ENV=development` enables a relaxed bypass for local development
+- **Next.js is a peer dependency** — supports `^14 || ^15 || ^16`. Do not move it to `dependencies`.
+- **Vitest, not Jest** — tests use Vitest. Do not introduce Jest.
+- **Publishes to GitHub Packages** — `npm.pkg.github.com`, public access under `@contentful` scope.
+
+## Never / Always
+
+- **Never** add a runtime dependency — keep this library zero-dependency.
+- **Never** manually bump the version — semantic-release handles it on `main`.
+- **Always** run `npm run build` before testing changes — both ESM and CJS outputs must build cleanly.
+- **Always** add a test in `lib/**/*.spec.ts` for any new handler behavior or utility change.

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,0 +1,79 @@
+# Architecture — @contentful/vercel-nextjs-toolkit
+
+## Overview
+
+A zero-dependency Next.js helper library. A single `enableDraftHandler` function (with App Router and Pages Router variants) that validates a Vercel bypass token and activates Next.js Draft Mode so content editors can preview unpublished Contentful content.
+
+## How It Works
+
+```
+Content Editor in Contentful
+  │
+  │  Clicks "Open Preview" → Contentful generates preview URL:
+  │  https://your-site.com/api/enable-draft?path=/blog/my-post&token=<bypass>
+  ▼
+Next.js route (app/api/enable-draft/route.ts or pages/api/enable-draft.ts)
+  └── enableDraftHandler(request)
+        │
+        ├── 1. Parse request URL → extract path, bypass token, host
+        ├── 2. Validate bypass token:
+        │       a. Try _vercel_jwt cookie (Vercel Protection Bypass JWT)
+        │       b. Fall back to CONTENTFUL_PREVIEW_SECRET env var
+        │       c. In development: relaxed validation
+        ├── 3. Call draftMode().enable() (Next.js Draft Mode)
+        └── 4. Redirect to requested path
+```
+
+## Module Map
+
+| File | Role |
+|------|------|
+| `lib/app-router/handlers/enable-draft.ts` | App Router handler — `(request: NextRequest) => Promise<Response>` |
+| `lib/pages-router/handlers/enable-draft.ts` | Pages Router handler — `(req: NextApiRequest, res: NextApiResponse) => Promise<void>` |
+| `lib/utils/vercelJwt.ts` | Gets + parses the `_vercel_jwt` cookie; validates bypass token |
+| `lib/utils/url.ts` | Parses request URL; builds redirect URL with bypass cookie |
+| `lib/types.ts` | `VercelJwt` interface — `{ bypass, aud, iat, sub }` |
+
+## Build Pipeline
+
+```
+tsc → type checking
+Vite → dual build:
+  dist/app-router.js    (ESM)
+  dist/app-router.cjs   (CJS)
+  dist/pages-router.js  (ESM)
+  dist/pages-router.cjs (CJS)
+  dist/app-router/index.d.ts
+  dist/pages-router/index.d.ts
+```
+
+Built via `vite build` with `vite-plugin-dts` for type generation. `prepack` runs `npm run build` automatically before any `npm publish`.
+
+## Token Validation Logic
+
+```
+Request arrives at /api/enable-draft?path=...&token=<bypass>
+  │
+  ├── Check _vercel_jwt cookie:
+  │     → Parse JWT (no signature verification — Vercel signs it, we just decode)
+  │     → Compare jwt.bypass against VERCEL_AUTOMATION_BYPASS_SECRET
+  │     → If match: valid ✓
+  │
+  ├── Fallback: Compare ?token query param against CONTENTFUL_PREVIEW_SECRET
+  │     → If match: valid ✓
+  │
+  └── NODE_ENV=development: simplified bypass (supports local dev without Vercel)
+```
+
+## Release
+
+Fully automated via semantic-release on the `main` branch. GitHub Actions workflow: lint → build → test → semantic-release → publish to GitHub Packages.
+
+## Key Dependencies
+
+| Package | Role |
+|---------|------|
+| `next` | Peer dep — App Router and Pages Router types |
+| `vite` + `vite-plugin-dts` | Build tooling (dev only) |
+| `vitest` | Test runner (dev only) |
+| `semantic-release` | Automated versioning + publish (dev only) |

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,52 @@
+# Contributing to @contentful/vercel-nextjs-toolkit
+
+## Prerequisites
+
+| Tool | Version |
+|------|---------|
+| Node.js | LTS/iron (`.nvmrc`) |
+| npm | bundled with Node |
+
+## Setup
+
+```bash
+git clone https://github.com/contentful/vercel-nextjs-toolkit.git
+cd vercel-nextjs-toolkit
+npm ci
+```
+
+## Running Tests
+
+```bash
+npm test
+```
+
+Tests use **Vitest**. Test files are co-located with source as `*.spec.ts`.
+
+## Building
+
+```bash
+npm run build
+```
+
+Runs `tsc` (type check) then `vite build`. Output goes to `dist/`. Both ESM and CJS formats are built for `app-router` and `pages-router` subpaths.
+
+## Code Conventions
+
+- **TypeScript** throughout, strict mode
+- **Zero runtime dependencies** — do not add any `dependencies` entries
+- **Conventional Commits** — `feat:`, `fix:`, `chore:`, `docs:`
+- `next` stays as a `peerDependency` — do not move it to `dependencies`
+- Prettier runs automatically on staged files via Husky pre-commit hook
+
+## Releasing
+
+Releases are automated via semantic-release on `main`. Do not manually bump versions.
+
+## Troubleshooting
+
+**Build fails with type errors**
+Ensure `next` types are available — run `npm ci` to confirm peer deps are installed correctly.
+
+**Tests failing for JWT validation**
+The JWT tests use real JWT fixtures. If the `_vercel_jwt` cookie shape changes, update `test/fixtures` and the `VercelJwt` type in `lib/types.ts`.


### PR DESCRIPTION
## Summary
- Adds `AGENTS.md`, `ARCHITECTURE.md`, and `CONTRIBUTING.md` to make this repo navigable for AI agents and new engineers without a human guide
- `AGENTS.md` covers the zero-dependency library design, dual App Router/Pages Router exports, and JWT validation logic
- `ARCHITECTURE.md` documents the Vercel bypass secret flow, CONTENTFUL_PREVIEW_SECRET fallback, and the two-export structure
- `CONTRIBUTING.md` documents the dev/test/release workflow

## Test plan
- [ ] Verify files render correctly on GitHub
- [ ] Spot-check that repo paths and commands referenced in the docs are accurate

Generated with [Claude Code](https://claude.com/claude-code)